### PR TITLE
WIP: Provide option to average trials in training set for crossvalidation

### DIFF
--- a/mvpa/cosmo_meansamples.m
+++ b/mvpa/cosmo_meansamples.m
@@ -1,0 +1,84 @@
+function [data, targets] = cosmo_meansamples(data, targets, nmean_trials)
+%MEG_AVERAGE_TRIALS averages the trials in data. It averages nmean_trials
+%for each condition until the trials are exhausted. If there remains less
+%than nmean_trials, all of them are averaged.
+%The function looks for conditions as specified into the field .trialinfo
+%by default. A different parameter can be passed with e.g., parameter =
+%'targets'.
+%data must be a timelocked FieldTrip structure (from FT_TIMELOCKANALYSIS).
+%Example call:
+%  data_avg = meg_average_trials(data, 5);
+%
+%  data_avg = meg_average_trials(data, 5, 'targets');
+
+% MVdOC Nov 2014
+if size(data, 1) ~= length(targets)
+    error('data and targets have different number of elements');
+end
+
+unique_targets = unique(targets);
+nunique_targets = length(unique_targets);
+
+% compute all the indices first
+indices = arrayfun(@(x) find(targets == x), ...
+    unique_targets', 'UniformOutput', 0);
+
+% check that we have enough data to average across all conditions
+min_ntrl = min(cell2mat(cellfun(@(x) length(x), indices, ...
+    'UniformOutput', 0)));
+
+if nmean_trials > min_ntrl
+    error(['Cannot average %d trials, minimum number of trials in ' ...
+    'one of the conditions is %d'], nmean_trials, min_ntrl);
+end
+
+out_avg_trial = cell([nunique_targets, 1]);
+out_avg_targets = cell([nunique_targets, 1]);
+[nsamples, nfeatures] = size(data);
+
+for icond = 1:nunique_targets
+    this_cond = unique_targets(icond);
+    idx = indices{icond};
+    temp_trial = data(idx, :);
+    
+    nidx = length(idx);
+    nremainder_trials = rem(nidx, nmean_trials);
+    naveraged_trials = floor(nidx/nmean_trials);
+    
+    start = 1;
+    if nremainder_trials ~= 0
+        avg_trial = zeros(naveraged_trials+1, nfeatures);
+        avg_trialinfo = ones([naveraged_trials+1, 1])*this_cond;
+        rand_idx = randsample(1:nidx, nremainder_trials);
+        % average these trials
+        avg_trial(1, :, :) = mean(temp_trial(rand_idx, :), 1);
+        % remove these trials
+        temp_trial(rand_idx, :) = [];
+        start = 2;
+    else
+        avg_trial = zeros(naveraged_trials, nfeatures);
+        avg_trialinfo = ones([naveraged_trials, 1])*this_cond;
+    end
+    for j = start:naveraged_trials+(start-1);
+        nidx = size(temp_trial, 1);
+        rand_idx = randsample(1:nidx, nmean_trials);
+        avg_trial(j, :) = mean(temp_trial(rand_idx, :), 1);
+        % remove these trials
+        temp_trial(rand_idx, :) = [];
+    end
+    
+    out_avg_trial{icond} = avg_trial;
+    out_avg_targets{icond} = avg_trialinfo;
+end
+
+data = cell2mat(out_avg_trial);
+targets = cell2mat(out_avg_targets);
+
+% check we have the same number of samples for each target
+% TODO: is this a good way to check that the chunk is balanced after
+% meaning?
+ntar = zeros(1, numel(unique(targets)));
+for tar = unique(targets)'
+    ntar(tar) = sum(targets == tar);
+end
+assert(length(unique(tar)) == 1);

--- a/tests/test_meansamples.m
+++ b/tests/test_meansamples.m
@@ -1,0 +1,25 @@
+function test_suite = test_meansamples
+    %initTestSuite;
+    test_meansamples_()
+
+function test_meansamples_()
+    ntargets=4;
+    nchunks=6;
+    
+    ds=cosmo_synthetic_dataset('ntargets', ntargets, 'nchunks', nchunks);
+    samples=ds.samples;
+    targets=ds.sa.targets;
+    
+    [mean_samples, mean_targets] = cosmo_meansamples(samples, targets, nchunks);
+    
+    assert(isequal(size(mean_samples), [ntargets, size(samples, 2)]));
+    for k=unique(targets)'
+       assert(sum((mean(samples(targets == k, :), 1) - mean_samples(k, :))) < 10^-15); 
+    end
+    
+    % check it doesn't puke with a different number of nmean_trl
+    try
+        [mean_samples, mean_targets] = cosmo_meansamples(samples, targets, 3);
+    catch err
+        rethrow(err);
+    end


### PR DESCRIPTION
This is a WIP: the PR is to discuss with you the benefits of this, and also to get advice to avoid breaking the API of cosmomvpa. 

- I added a minimal test because I wasn't sure which platform I should use, whether xUnit or your modified version of it. 
- I also modified the `demo_meeg_timeseries_classification.m`.
- The docstrings are not updated yet.

This is an example of the output of the demo showing a benefit of averaging 5 trials in the training set prior to classification -- bottom row is with averaging.

![average_trials](https://cloud.githubusercontent.com/assets/6150554/8767949/52862d80-2e3c-11e5-8950-e1fc3e0e7a2f.png)

Things to do:
- [ ] check that everything is kosher
- [ ] check that averaging the trials doesn't break the balanced partitions -- atm there is an assertion, but I think it's quite weak.
- [ ] possibly implement a similar option for averaging in the test set as well