### PR TITLE
BF+BK+ACK: fix wrong output when using cosmo_montecarlo_cluster_stat 

### DIFF
--- a/mvpa/cosmo_montecarlo_cluster_stat.m
+++ b/mvpa/cosmo_montecarlo_cluster_stat.m
@@ -478,7 +478,8 @@ function permuter_func=get_permuter_preproc_none_func(ds,preproc_func,opt)
         error(['The option ''null'' is required '...
                         'with ''none'' statfunc']);
     end
-    permuter_func=@(iter)opt.null{iter};
+
+    permuter_func=@(iter) preproc_func(opt.null{iter});
 
 function permuter_func=get_permuter_preproc_stat_func(ds,preproc_func,opt)
 

--- a/tests/test_montecarlo_cluster_stat.m
+++ b/tests/test_montecarlo_cluster_stat.m
@@ -327,6 +327,28 @@ function test_feature_stat_montecarlo_cluster_stat
     assertEqual(res.fa,ds1.fa);
     assertEqual(res.a,ds1.a);
 
+    % h0_mean shoudl work
+    c=8+rand();
+    null_cell_const=null_cell;
+    for k=1:numel(null_cell_const)
+        null_cell_const{k}.samples=null_cell_const{k}.samples+c;
+    end
+
+    ds1_const=ds1;
+    ds1_const.samples=ds1_const.samples+c;
+
+
+    opt.h0_mean=c;
+    opt.null=null_cell_const;
+
+    res_const=cosmo_montecarlo_cluster_stat(ds1_const,nh,opt);
+    assertElementsAlmostEqual(res_const.samples,res.samples,...
+                                'absolute',1e-4);
+    assertEqual(res.fa,res_const.fa);
+    assertEqual(res.a,res_const.a);
+
+
+
 
 function test_montecarlo_cluster_stat_exceptions
     aet=@(varargin)assertExceptionThrown(@()...


### PR DESCRIPTION
Issue caused when both feature_stat=none and h0_mean=c for c~=0. As a result, output maps were biased, showing either too many negative [positive] clusters for positive [negative] values of c. Thanks to #Moritz Wurm# for asking a question about this