### PR TITLE
 cmpt/run sequantially

### DIFF
--- a/tests/test_isequaln.m
+++ b/tests/test_isequaln.m
@@ -61,7 +61,7 @@ function helper_test_comparison(func)
     if cosmo_skip_test_if_no_external(ext_name)
         return
     end
-    
+
     warning_state=warning();
     warning_resetter=onCleanup(@()warning(warning_state));
     warning('off','Octave:deprecated-keyword');

--- a/tests/test_run_tests.m
+++ b/tests/test_run_tests.m
@@ -64,12 +64,11 @@ function [result,output]=helper_run_tests(args)
     orig_pwd=pwd();
     log_fn=tempname();
 
-    run_sequentially=@(varargin)cellfun(@(f)f(),varargin);
-    cleaner=onCleanup(@()run_sequentially(...
+    cleaner=onCleanup(@()run_sequentially({...
                             @()path(orig_path),...
                             @()cosmo_warning(warning_state),...
                             @()cd(orig_pwd),...
-                            @()delete_if_exists(log_fn)));
+                            @()delete_if_exists(log_fn)}));
 
     % ensure path is set; disable warnings by cosmo_set_path
     cosmo_warning('off');
@@ -79,6 +78,13 @@ function [result,output]=helper_run_tests(args)
     fid=fopen(log_fn);
     output=fread(fid,Inf,'char=>char')';
 
+
+function run_sequentially(cell_with_funcs)
+    n=numel(cell_with_funcs);
+    for k=1:n
+        func=cell_with_funcs{k};
+        func();
+    end
 
 function delete_if_exists(fn)
     if exist(fn,'file')


### PR DESCRIPTION
Run functions with separate subfunction. Could be due to change in Octave 4.0.3, as the refactoring fixes the failing tests for https://github.com/CoSMoMVPA/CoSMoMVPA/pull/63 and https://github.com/CoSMoMVPA/CoSMoMVPA/pull/76 to fail on travis. 
See https://travis-ci.org/CoSMoMVPA/CoSMoMVPA/builds/145707072 and https://travis-ci.org/CoSMoMVPA/CoSMoMVPA/builds/145742729