### PR TITLE
BF+TST: balanced accuracy

### DIFF
--- a/mvpa/cosmo_crossvalidation_measure.m
+++ b/mvpa/cosmo_crossvalidation_measure.m
@@ -13,7 +13,7 @@ function ds_sa = cosmo_crossvalidation_measure(ds, varargin)
 %                       @classify_naive_baysian
 %   args.partitions     Partition scheme, for example the output from
 %                       cosmo_nfold_partition
-%   args.output         'accuracy' (default), 'balanced_accuracy', 
+%   args.output         'accuracy' (default), 'balanced_accuracy',
 %                       'predictions', or 'accuracy_by_chunk'
 %   args.check_partitions  optional (default: true). If set to false then
 %                          partitions are not checked for being set
@@ -167,16 +167,22 @@ switch params.output
     case 'accuracy'
         ds_sa.samples=accuracy;
         ds_sa.sa.labels={'accuracy'};
-        
+
     case 'balanced_accuracy'
         classes = unique(ds.sa.targets);
         ba = zeros(1,length(classes));
+        has_predictions = ~isnan(pred);
         for c=1:length(classes)
-            idx = ds.sa.targets==classes(c);
+            % some samples may be without predictions (and are set to NaN
+            % by cosmo_crossvalidate). Consider only the samples with
+            % predicitons, and compute for each class the classification
+            % accuracy
+            idx = ds.sa.targets==classes(c) & has_predictions;
             ba(c) = mean(ds.sa.targets(idx)==pred(idx));
         end
         ds_sa.samples=mean(ba);
         ds_sa.sa.labels={'balanced_accuracy'};
+
 
     case {'predictions','raw'}
         ds_sa.sa=ds.sa;

--- a/tests/test_crossvalidation_measure.m
+++ b/tests/test_crossvalidation_measure.m
@@ -89,6 +89,118 @@ function test_crossvalidation_measure_exceptions
     aet(ds,opt);
 
 
+function test_balanced_accuracy()
+    nclasses=10;
+    nchunks=20;
+    ds=cosmo_synthetic_dataset('ntargets',nclasses,...
+                                'nchunks',nchunks,...
+                                'nreps',4);
+
+    % shuffle targets, use random data - assume data is unbalanced
+    % afterwards
+    ds.samples=randn(size(ds.samples));
+
+    nsamples=size(ds.samples,1);
+    while true
+        ds.sa.targets=ceil(rand(nsamples,1)*nclasses);
+        ds.sa.chunks=ceil(rand(nsamples,1)*nchunks);
+
+        h_t=histc(ds.sa.targets,1:nclasses);
+        h_c=histc(ds.sa.chunks,1:nchunks);
+
+        if numel(h_t)~=nclasses || ...
+                numel(h_c)~=nchunks
+            % classes or chunsk missing, regenerate
+            continue;
+        end
+
+        if any(h_t~=nclasses) && any(h_c~=nchunks)
+            % inbalance
+            break;
+        end
+    end
+
+    % keep subset of all partitions, so that there are missing predictions
+    % for some of the samples
+    partitions=cosmo_nfold_partitioner(ds);
+    nkeep=ceil(.3*nchunks);
+    partitions.train_indices=partitions.train_indices(1:nkeep);
+    partitions.test_indices=partitions.test_indices(1:nkeep);
+
+    % compute balanced accuracy
+    opt=struct();
+    opt.classifier=@cosmo_classify_nn;
+    opt.partitions=partitions;
 
 
+    % without check_partitions, an exception should be thrown as the
+    % partitions are supposed to be unbalanced
+    assertExceptionThrown(@()...
+                        cosmo_check_partitions(partitions,ds),'');
+    assertExceptionThrown(@()...
+                        cosmo_crossvalidation_measure(ds,opt),'');
+    opt.check_partitions=false;
+
+    % compute accuracy
+    opt.output='balanced_accuracy';
+    ba_result=cosmo_crossvalidation_measure(ds,opt);
+
+    opt.output='predictions';
+    pred_result=cosmo_crossvalidation_measure(ds,opt);
+
+    opt.output='accuracy';
+    acc_result=cosmo_crossvalidation_measure(ds,opt);
+
+    % check fields
+    result_cell={ba_result,acc_result};
+    for k=1:numel(result_cell)
+        result=result_cell{k};
+
+        assertEqual(sort(fieldnames(result)),sort({'samples';'sa'}));
+        assertEqual(fieldnames(result.sa),{'labels'});
+    end
+
+    assertEqual(ba_result.sa.labels,{'balanced_accuracy'});
+    assertEqual(acc_result.sa.labels,{'accuracy'});
+
+
+    % compute expected result for balanced accuracy
+    [unused,unused,target_idx]=unique(ds.sa.targets);
+    assert(max(target_idx)==nclasses);
+    nfolds=numel(partitions.train_indices);
+
+    correct_count=zeros(nfolds,nclasses);
+    class_count=zeros(1,nclasses);
+
+    all_pred=NaN(nsamples,1);
+
+    for fold_i=1:nfolds
+        tr_idx=partitions.train_indices{fold_i};
+        te_idx=partitions.test_indices{fold_i};
+
+        ds_tr=cosmo_slice(ds,tr_idx);
+        ds_te=cosmo_slice(ds,te_idx);
+
+        target_idx_te=target_idx(te_idx);
+
+        pred=opt.classifier(ds_tr.samples,...
+                            ds_tr.sa.targets,...
+                            ds_te.samples);
+        all_pred(te_idx)=pred;
+        for class_i=1:nclasses
+            target_msk=target_idx_te==class_i;
+            is_correct=pred(target_msk)==ds_te.sa.targets(target_msk);
+            correct_count(fold_i,class_i)=sum(is_correct);
+            class_count(class_i)=class_count(class_i)+numel(is_correct);
+        end
+    end
+
+    class_acc=bsxfun(@rdivide,sum(correct_count,1),class_count);
+
+    % verify expected result for balanced accuracy
+    assertElementsAlmostEqual(mean(class_acc),ba_result.samples);
+
+    % verify expected result for predictions of each class
+    assertEqual(pred_result.samples,all_pred);
+    assertEqual(pred_result.sa.targets,ds.sa.targets);
 


### PR DESCRIPTION
This modifies PR #76 by:
- adding a unit test
- ensuring that the values are correct, even when not all samples have a prediction