### PR TITLE
OCTV+BF+ACK: always use {X,Y}Tick when using {X,Y}TickLabel 

### DIFF
--- a/doc/source/thanks.rst
+++ b/doc/source/thanks.rst
@@ -47,6 +47,7 @@ The following people have provided valuable suggestions, advice, support, or cod
 + Seth Levine
 + Stefania Mattioni
 + Mike Miller
++ Maria Montchal
 + Sam Nastase
 + Liuba Papeo
 + Nicholas Peatfield

--- a/examples/demo_fmri_distatis.m
+++ b/examples/demo_fmri_distatis.m
@@ -78,11 +78,12 @@ distatis=cosmo_distatis(all_ds);
 [compromise_matrix,dim_labels,values]=cosmo_unflatten(distatis,1);
 
 labels={'monkey', 'lemur', 'mallard', 'warbler', 'ladybug', 'lunamoth'};
+n_labels=numel(labels);
 figure();
 imagesc(compromise_matrix)
 title('DSM');
-set(gca,'YTickLabel',labels);
-set(gca,'XTickLabel',labels);
+set(gca,'YTick',1:n_labels,'YTickLabel',labels);
+set(gca,'XTick',1:n_labels,'XTickLabel',labels);
 ylabel(dim_labels{1});
 xlabel(dim_labels{2});
 colorbar

--- a/examples/demo_fmri_rois.m
+++ b/examples/demo_fmri_rois.m
@@ -173,6 +173,7 @@ nclassifiers=numel(classifiers);
 nmasks=numel(mask_labels);
 
 labels={'monkey', 'lemur', 'mallard', 'warbler', 'ladybug', 'lunamoth'};
+nlabels=numel(labels);
 
 % little helper function to replace underscores by spaces
 underscore2space=@(x) strrep(x,'_',' ');
@@ -210,8 +211,8 @@ for j=1:nmasks
         title_=sprintf('%s using %s: accuracy=%.3f', ...
                         underscore2space(mask_label), cfy_label, accuracy);
         title(title_)
-        set(gca,'XTickLabel',labels);
-        set(gca,'YTickLabel',labels);
+        set(gca,'XTick',1:nlabels,'XTickLabel',labels);
+        set(gca,'YTick',1:nlabels,'YTickLabel',labels);
         ylabel('target');
         xlabel('predicted');
     end

--- a/examples/run_classify_lda.m
+++ b/examples/run_classify_lda.m
@@ -176,8 +176,8 @@ end
 figure
 imagesc(confusion_matrix,[0 5])
 title('confusion matrix');
-set(gca,'XTickLabel',classes);
-set(gca,'YTickLabel',classes);
+set(gca,'XTick',1:nclasses,'XTickLabel',classes);
+set(gca,'YTick',1:nclasses,'YTickLabel',classes);
 ylabel('target');
 xlabel('predicted');
 colorbar

--- a/examples/run_crossvalidation_measure.m
+++ b/examples/run_crossvalidation_measure.m
@@ -160,8 +160,9 @@ for k=1:nclassifiers
 
 
     classes = {'monkey','lemur','mallard','warbler','ladybug','lunamoth'};
-    set(gca,'XTickLabel',classes);
-    set(gca,'YTickLabel',classes);
+    nclasses=numel(classes);
+    set(gca,'XTick',1:nclasses,'XTickLabel',classes);
+    set(gca,'YTick',1:nclasses,'YTickLabel',classes);
     ylabel('target');
     xlabel('predicted');
     colorbar

--- a/examples/run_nfold_crossvalidate.m
+++ b/examples/run_nfold_crossvalidate.m
@@ -129,7 +129,7 @@ fprintf('\nLDA all categories n-fold: accuracy %.3f\n', accuracy);
 % the cosmo_confusion_matrix convenience function is used to compute the
 % confusion matrix
 [confusion_matrix,classes]=cosmo_confusion_matrix(ds.sa.targets,all_pred);
-
+nclasses=numel(classes);
 % print confusion matrix to terminal window
 fprintf('\nLDA n-fold cross-validation confusion matrix:\n')
 disp(confusion_matrix);
@@ -138,8 +138,8 @@ disp(confusion_matrix);
 figure
 imagesc(confusion_matrix,[0 10])
 title('confusion matrix');
-set(gca,'XTickLabel',classes);
-set(gca,'YTickLabel',classes);
+set(gca,'XTick',1:nclasses,'XTickLabel',classes);
+set(gca,'YTick',1:nclasses,'YTickLabel',classes);
 ylabel('target');
 xlabel('predicted');
 colorbar


### PR DESCRIPTION
when producing plots, as otherwise Octave may show a wrong label order. Thanks to #Maria Montchal# for reporting the issue