### PR TITLE
BF cosmo_config.m was unable to find the configuration file under

### DIFF
--- a/mvpa/cosmo_config.m
+++ b/mvpa/cosmo_config.m
@@ -177,7 +177,7 @@ function path_fn=find_config_file(fn, raise_)
         % is it in the user path?
         % (not supported on octave)
         if cosmo_wtf('is_matlab')
-            upaths=cosmo_strsplit(userpath(),':');
+            upaths=cosmo_strsplit(userpath(),';');
             for k=1:numel(upaths)
                 u_fn=fullfile(upaths{k},fn);
                 if exist_(u_fn)

--- a/mvpa/cosmo_config.m
+++ b/mvpa/cosmo_config.m
@@ -178,6 +178,7 @@ function path_fn=find_config_file(fn, raise_)
         % (not supported on octave)
         if cosmo_wtf('is_matlab')
             upaths=cosmo_strsplit(userpath(),';');
+            %if strncmp(upaths{2}(end),';',1); upaths{2} = upaths{2}(1:end-1); end
             for k=1:numel(upaths)
                 u_fn=fullfile(upaths{k},fn);
                 if exist_(u_fn)


### PR DESCRIPTION
windows. Probably because MATLAB appends ";" to the userpath and
cosmo_config.m was looking for a ":" instead.
Works like this.
Cheers,
Yamil