### PR TITLE
ENH+ACK: show warning when using cosmo_correlation_measure with non-default settings…

### DIFF
--- a/mvpa/cosmo_correlation_measure.m
+++ b/mvpa/cosmo_correlation_measure.m
@@ -228,6 +228,8 @@ else
 
     params=cosmo_structjoin(defaults, varargin);
 
+    show_warning_if_no_defaults(defaults,params);
+
     cached_params=params;
     cached_varargin=varargin;
 end
@@ -423,3 +425,28 @@ function data=get_data(ds, sample_idxs, class_ids, merge_func)
     end
 
 
+function show_warning_if_no_defaults(defaults,params)
+    keys={'output','post_corr_func'};
+    has_defaults=isequal(select_fields(defaults,keys),...
+                         select_fields(params,keys));
+
+    if ~has_defaults && isequal(params.post_corr_func,@atanh)
+        name=mfilename();
+        msg=sprintf(...
+                ['Please note that the ''%s'' function applies '...
+                'Fisher transformation after the correlations '...
+                'have been computed. This was a somewhat unfortunate '...
+                'implementation decision that will not be changed '...
+                'to avoid breaking behaviour with earlier versions.\n'...
+                'To disable using the Fisher transformation, use the '...
+                '''%s'' function while setting the ''post_corr_func'''...
+                'option to the empty array ([])'],name,name);
+        cosmo_warning(msg);
+    end
+
+function subset=select_fields(s, keys)
+    n=numel(keys);
+    for k=1:n
+        key=keys{k};
+        subset.(key)=s.(key);
+    end

--- a/tests/test_correlation_measure.m
+++ b/tests/test_correlation_measure.m
@@ -30,6 +30,12 @@ function test_correlation_measure_basis()
     assertElementsAlmostEqual(delta,c1.samples,'relative',1e-5);
     assertEqual(c1.sa.labels,{'corr'});
 
+    % reset state and do not show warnings
+    orig_warning_state=cosmo_warning();
+    warning_cleaner=onCleanup(@()cosmo_warning(orig_warning_state));
+    cosmo_warning('reset');
+    cosmo_warning('off');
+
     c2=cosmo_correlation_measure(ds,'output','correlation');
     assertElementsAlmostEqual(reshape(cxy,[],1),c2.samples);
     assertEqual(kron((1:4)',ones(4,1)),c2.sa.half2);
@@ -99,6 +105,12 @@ function test_correlation_measure_regression_spearman()
     helper_test_correlation_measure_regression(true);
 
 function helper_test_correlation_measure_regression(test_spearman)
+    % reset state and do not show warnings
+    orig_warning_state=cosmo_warning();
+    warning_cleaner=onCleanup(@()cosmo_warning(orig_warning_state));
+    cosmo_warning('reset');
+    cosmo_warning('off');
+
     ds=cosmo_synthetic_dataset('ntargets',3,'nchunks',5,'sigma',.5);
     params=get_regression_test_params(test_spearman);
 
@@ -189,6 +201,12 @@ function test_correlation_measure_exceptions
     aet=@(varargin)assertExceptionThrown(@()...
                 cosmo_correlation_measure(varargin{:}),'');
 
+    % reset state and do not show warnings
+    orig_warning_state=cosmo_warning();
+    warning_cleaner=onCleanup(@()cosmo_warning(orig_warning_state));
+    cosmo_warning('reset');
+    cosmo_warning('off');
+
     ds=cosmo_synthetic_dataset('nchunks',2);
     aet(ds,'template',eye(4));
     aet(ds,'output','foo');
@@ -203,3 +221,53 @@ function test_correlation_measure_exceptions
 
     ds.sa.targets(1)=2;
     aet(ds);
+
+function x=identity(x)
+
+function test_correlation_measure_warning_shown_if_no_defaults()
+    orig_warning_state=cosmo_warning();
+    cleaner=onCleanup(@()cosmo_warning(orig_warning_state));
+
+    % reset state and do not show warnings
+    cosmo_warning('reset');
+    cosmo_warning('off');
+
+    funcs={[],@atanh};
+    outputs={[],'mean','raw','correlation'};
+
+
+
+    for k=1:numel(funcs)
+        func=funcs{k};
+        for j=1:numel(outputs)
+            output=outputs{j};
+
+            is_default_func=k<=2;
+            is_default_output=j<=2;
+            expect_warning=~(is_default_func && is_default_output);
+
+            opt=struct();
+            if ~isempty(func)
+                opt.post_corr_func=func;
+            end
+
+            if ~isempty(output)
+                opt.output=output;
+            end
+
+            cosmo_warning('reset');
+            cosmo_warning('off');
+
+            ds=cosmo_synthetic_dataset('nchunks',2);
+            cosmo_correlation_measure(ds,opt);
+
+            s=cosmo_warning();
+
+            showed_warning=numel(s.shown_warnings)>0;
+
+            assertEqual(expect_warning,showed_warning);
+        end
+    end
+
+
+


### PR DESCRIPTION
Thanks to James Keidel for suggesting this feature